### PR TITLE
Add a “Deadline” field to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-issue.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-issue.md
@@ -14,3 +14,6 @@ Detail how you think this bug should be fixed. Include any technical details, if
 
 ## Additional Context
 Add any other context or screenshots related to the request here.
+
+## Deadline
+Write the deadline of the issue here

--- a/.github/ISSUE_TEMPLATE/feature-request-issue.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-issue.md
@@ -16,3 +16,6 @@ Detail how you think this feature should work. Include any technical details, if
 Add any other context or screenshots related to the request here.
 
 ## Acceptance Criteria
+
+## Deadline
+Write the deadline of the issue here

--- a/.github/ISSUE_TEMPLATE/meeting_agenda.md
+++ b/.github/ISSUE_TEMPLATE/meeting_agenda.md
@@ -25,3 +25,6 @@ _What is the goal of this meeting? (e.g., project update, brainstorming, decisio
    - Discussion points  
 
 ---
+
+## Deadline
+Write the deadline of the issue here

--- a/.github/ISSUE_TEMPLATE/todo-issue.md
+++ b/.github/ISSUE_TEMPLATE/todo-issue.md
@@ -14,3 +14,6 @@ Describe what needs to be done.
 Add any other info or relevant details here.
 
 ## Acceptance Criteria
+
+## Deadline
+Write the deadline of the issue here


### PR DESCRIPTION
This pull request introduces a “Deadline” field across all issue templates. The change makes it easier to specify a target completion date when creating new issues. No other functionality is affected. Closes #36.