### PR TITLE
fix: export API_ORIGIN so frontend can load without blank screen

### DIFF
--- a/app/frontend/src/services/api.ts
+++ b/app/frontend/src/services/api.ts
@@ -16,7 +16,6 @@ function getApiBaseUrl(): string {
       const ipMatch = currentOrigin.match(/^https?:\/\/([\d.]+)(:\d+)?/);
       if (ipMatch) {
         const ip = ipMatch[1];
-        const port = ipMatch[2] || '';
         return `http://${ip}:8000/api`;
       }
     }
@@ -29,7 +28,8 @@ function getApiBaseUrl(): string {
 }
 
 // Create an axios instance with base URL
-const API_BASE_URL: string = getApiBaseUrl();
+export const API_BASE_URL: string = getApiBaseUrl();
+export const API_ORIGIN: string = new URL(API_BASE_URL).origin;
 const api = axios.create({
   baseURL: API_BASE_URL,
   headers: {


### PR DESCRIPTION
Fix frontend boot failure caused by API_ORIGIN import: exported both API_BASE_URL and API_ORIGIN from src/services/api.ts, so toAbsoluteUrl can resolve relative asset URLs without throwing.

This fix solves the access problem of our main branch also. So this issue closes both its BUG issue and deployment issue.

closes #605 
closes #613 