### PR TITLE
Switch to global Country/State/City data source 

### DIFF
--- a/app/mobile/app/cr_address.tsx
+++ b/app/mobile/app/cr_address.tsx
@@ -47,6 +47,7 @@ export default function CRAddress() {
       const people = parseInt(params.people as string) || 1;
       const deadline =
         (params.deadline as string) || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      const deadlineDate = new Date(deadline);
 
       if (!title || !taskDescription || !category) {
         Alert.alert('Error', 'Missing task data. Please go back and try again.');
@@ -54,8 +55,20 @@ export default function CRAddress() {
         return;
       }
 
-      if (!address.city || !address.district) {
-        Alert.alert('Error', 'Please select a city and district for the address.');
+      if (Number.isNaN(deadlineDate.getTime())) {
+        Alert.alert('Error', 'Invalid deadline. Please pick a valid deadline.');
+        setUploading(false);
+        return;
+      }
+
+      if (deadlineDate.getTime() <= Date.now()) {
+        Alert.alert('Invalid Deadline', 'Please select a future date and time.');
+        setUploading(false);
+        return;
+      }
+
+      if (!address.country || !address.state || !address.city) {
+        Alert.alert('Error', 'Please select a country, state and city for the address.');
         return;
       }
 

--- a/app/mobile/components/forms/AddressFields.tsx
+++ b/app/mobile/components/forms/AddressFields.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { View, Text, TouchableOpacity, TextInput, Modal, ScrollView, StyleSheet } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
-import * as turkeyData from 'turkey-neighbourhoods';
+import { Country, State, City } from 'country-state-city';
 import { AddressFieldsValue } from '../../utils/address';
 
 interface AddressFieldsProps {
@@ -11,13 +11,17 @@ interface AddressFieldsProps {
   labelPrefix?: string;
 }
 
-const cityNamesByCode = turkeyData.cityNamesByCode as Record<string, string>;
-const CITY_LIST = turkeyData.getCityNames();
+// --- Data Preparation (Outside Component) ---
+const all_countries = Country.getAllCountries();
 
-const cityNameToCode: Record<string, string> = {};
-Object.entries(cityNamesByCode).forEach(([code, name]) => {
-  cityNameToCode[name] = code;
+const countryNameToCode: Record<string, string> = {};
+all_countries.forEach(c => {
+  countryNameToCode[c.name] = c.isoCode;
 });
+
+// List of all country names for the picker
+const COUNTRY_LIST = all_countries.map(c => c.name).sort();
+
 
 export function AddressFields({ value, onChange, labelPrefix = '' }: AddressFieldsProps) {
   const { colors } = useTheme();
@@ -47,76 +51,141 @@ export function AddressFields({ value, onChange, labelPrefix = '' }: AddressFiel
 
   const closePicker = () => setPickerModal((prev) => ({ ...prev, visible: false }));
 
-  const getDistricts = useMemo(() => {
-    const code = cityNameToCode[value.city];
-    if (!code) return [];
-    return turkeyData.getDistrictsByCityCode(code) ?? [];
-  }, [value.city]);
+  // 1. Get States
+  const [statesList, stateNameToCode] = useMemo(() => {
+      const countryCode = countryNameToCode[value.country];
+      if (!countryCode) return [[], {}];
+      
+      const states = State.getStatesOfCountry(countryCode);
+      const names = states.map(s => s.name).sort();
+      
+      const nameToCode: Record<string, string> = {};
+      states.forEach(s => {
+        nameToCode[s.name] = s.isoCode;
+      });
 
-  const getNeighborhoods = useMemo(() => {
-    const cityCode = cityNameToCode[value.city];
-    if (!cityCode || !value.district) return [];
-    return turkeyData.getNeighbourhoodsByCityCodeAndDistrict(cityCode, value.district) ?? [];
-  }, [value.city, value.district]);
+      return [names, nameToCode];
+    }, [value.country]);
 
+  // 2. Get Cities (Simplified return value)
+  const citiesList = useMemo(() => {
+      const countryCode = countryNameToCode[value.country];
+
+      const stateMap = stateNameToCode as Record<string, string>; 
+      
+      const stateCode = stateMap[value.state]; // Use the asserted type
+      
+      if (!countryCode || !stateCode) return [];
+      
+      const cities = City.getCitiesOfState(countryCode, stateCode);
+      const names = cities.map(c => c.name).sort();
+
+      return names; 
+    }, [value.country, value.state, stateNameToCode]);
+
+  // 3. Update Logic (Clear dependents only when parent selector changes)
   const updateField = (field: keyof AddressFieldsValue, fieldValue: string) => {
-    const next: AddressFieldsValue = { ...value, [field]: fieldValue };
-    if (field === 'city') {
-      next.district = '';
-      next.neighborhood = '';
-    }
-    if (field === 'district') {
-      next.neighborhood = '';
-    }
-    onChange(next);
-  };
+      const next: AddressFieldsValue = { ...value, [field]: fieldValue };
+      
+      if (field === 'country') {
+        // Clear all dependent selection fields AND all free-text locality fields
+        next.state = ''; 
+        next.city = '';
+        next.neighborhood = '';
+        next.street = '';
+      } else if (field === 'state') {
+        // Clear city selection field
+        next.city = '';
+        // Do NOT clear free-text fields
+      } else if (field === 'city') {
+        // No fields cleared below city
+      }
+      
+      onChange(next);
+    };
 
   return (
     <View>
-      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}City</Text>
+      {/* 1. Country Selector */}
+      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}Country</Text>
       <TouchableOpacity
         style={[styles.selectorButton, { borderColor: colors.border, backgroundColor: colors.card }]}
-        onPress={() => openPicker('Select City', CITY_LIST, value.city, (val) => updateField('city', val))}
+        onPress={() => openPicker('Select Country', COUNTRY_LIST, value.country, (val) => updateField('country', val))}
       >
-        <Text style={[styles.selectorText, { color: colors.text }]}>{value.city || 'Select city'}</Text>
+        <Text style={[styles.selectorText, { color: colors.text }]}>{value.country || 'Select country'}</Text>
         <Ionicons name="chevron-down" size={20} color={colors.border} />
       </TouchableOpacity>
 
-      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}District</Text>
+      {/* 2. State/Region Selector */}
+      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}State/Region</Text>
       <TouchableOpacity
         style={[
           styles.selectorButton,
-          { borderColor: colors.border, backgroundColor: colors.card, opacity: value.city ? 1 : 0.6 },
+          { borderColor: colors.border, backgroundColor: colors.card, opacity: value.country ? 1 : 0.6 },
         ]}
-        disabled={!value.city}
-        onPress={() =>
-          openPicker('Select District', getDistricts, value.district, (val) => updateField('district', val))
-        }
+        disabled={!value.country || statesList.length === 0}
+        onPress={() => openPicker('Select State/Region', statesList, value.state, (val) => updateField('state', val))}
       >
-        <Text style={[styles.selectorText, { color: colors.text }]}>{value.district || 'Select district'}</Text>
+        <Text style={[styles.selectorText, { color: colors.text }]}>
+          {value.state || (statesList.length > 0 ? 'Select state/region' : 'Select Country first')}
+        </Text>
         <Ionicons name="chevron-down" size={20} color={colors.border} />
       </TouchableOpacity>
+      
+      {/* Fallback Input for State/Region if data is missing 
+      {value.country && statesList.length === 0 && (
+          <TextInput
+            style={[styles.input, { borderColor: colors.border, backgroundColor: colors.card, color: colors.text, marginTop: 8 }]}
+            placeholder={`Enter State/Region for ${value.country}`}
+            placeholderTextColor={colors.border}
+            value={value.state}
+            onChangeText={(text) => updateField('state', text)}
+          />
+        )}
+      */}
 
-      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}Neighborhood</Text>
+
+      {/* 3. City Selector */}
+      <Text style={[styles.label, { color: colors.text }]}>{labelPrefix}City</Text>
       <TouchableOpacity
         style={[
           styles.selectorButton,
-          { borderColor: colors.border, backgroundColor: colors.card, opacity: value.district ? 1 : 0.6 },
+          { borderColor: colors.border, backgroundColor: colors.card, opacity: value.state ? 1 : 0.6 },
         ]}
-        disabled={!value.district}
-        onPress={() =>
-          openPicker(
-            'Select Neighborhood',
-            getNeighborhoods,
-            value.neighborhood,
-            (val) => updateField('neighborhood', val),
-          )
-        }
+        disabled={!value.state || citiesList.length === 0}
+        onPress={() => openPicker('Select City', citiesList, value.city, (val) => updateField('city', val))}
       >
-        <Text style={[styles.selectorText, { color: colors.text }]}>{value.neighborhood || 'Select neighborhood'}</Text>
+        <Text style={[styles.selectorText, { color: colors.text }]}>
+          {value.city || (citiesList.length > 0 ? 'Select city' : 'Select Country/State first')}
+        </Text>
         <Ionicons name="chevron-down" size={20} color={colors.border} />
       </TouchableOpacity>
+      
+      {/* Fallback Input for City if data is missing
+      {value.state && citiesList.length === 0 && (
+          <TextInput
+            style={[styles.input, { borderColor: colors.border, backgroundColor: colors.card, color: colors.text, marginTop: 8 }]}
+            placeholder={`Enter City`}
+            placeholderTextColor={colors.border}
+            value={value.city}
+            onChangeText={(text) => updateField('city', text)}
+          />
+        )}
+      */}
+        
 
+
+      {/* 5. Neighborhood (Free Text) */}
+      <Text style={[styles.label, { color: colors.text }]}>Neighborhood</Text>
+      <TextInput
+        style={[styles.input, { borderColor: colors.border, backgroundColor: colors.card, color: colors.text }]}
+        placeholder="Neighborhood"
+        placeholderTextColor={colors.border}
+        value={value.neighborhood}
+        onChangeText={(text) => updateField('neighborhood', text)}
+      />
+
+      {/* 6. Street Line 2 (Free Text) */}
       <Text style={[styles.label, { color: colors.text }]}>Street</Text>
       <TextInput
         style={[styles.input, { borderColor: colors.border, backgroundColor: colors.card, color: colors.text }]}
@@ -126,6 +195,7 @@ export function AddressFields({ value, onChange, labelPrefix = '' }: AddressFiel
         onChangeText={(text) => updateField('street', text)}
       />
 
+      {/* Building and Door Numbers */}
       <View style={styles.row}>
         <View style={{ flex: 1, marginRight: 8 }}>
           <Text style={[styles.label, { color: colors.text }]}>Building No</Text>
@@ -149,6 +219,7 @@ export function AddressFields({ value, onChange, labelPrefix = '' }: AddressFiel
         </View>
       </View>
 
+      {/* Modal remains the same */}
       <Modal transparent visible={pickerModal.visible} animationType="fade" onRequestClose={closePicker}>
         <View style={styles.overlay}>
           <View style={[styles.modalContent, { backgroundColor: colors.card }]}>
@@ -190,6 +261,7 @@ export function AddressFields({ value, onChange, labelPrefix = '' }: AddressFiel
 }
 
 const styles = StyleSheet.create({
+  // ... (styles are unchanged)
   label: {
     fontSize: 16,
     fontWeight: '600',

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "axios": "^1.12.2",
+        "country-state-city": "^3.2.1",
         "expo": "~54.0.12",
         "expo-constants": "~18.0.9",
         "expo-font": "~14.0.8",
@@ -5859,6 +5860,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/country-state-city": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/country-state-city/-/country-state-city-3.2.1.tgz",
+      "integrity": "sha512-kxbanqMc6izjhc/EHkGPCTabSPZ2G6eG4/97akAYHJUN4stzzFEvQPZoF8oXDQ+10gM/O/yUmISCR1ZVxyb6EA==",
+      "license": "GPL-3.0"
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "axios": "^1.12.2",
+    "country-state-city": "^3.2.1",
     "expo": "~54.0.12",
     "expo-constants": "~18.0.9",
     "expo-font": "~14.0.8",

--- a/app/mobile/utils/address.ts
+++ b/app/mobile/utils/address.ts
@@ -1,6 +1,7 @@
 export interface AddressFieldsValue {
+  country: string;
+  state: string;
   city: string;
-  district: string;
   neighborhood: string;
   street: string;
   buildingNo: string;
@@ -8,8 +9,9 @@ export interface AddressFieldsValue {
 }
 
 export const emptyAddress: AddressFieldsValue = {
+  country: '',
+  state: '',
   city: '',
-  district: '',
   neighborhood: '',
   street: '',
   buildingNo: '',
@@ -26,14 +28,16 @@ export const parseAddressString = (location?: string | null): AddressFieldsValue
     .map((part) => part.trim())
     .filter(Boolean);
 
+  const country = parts.pop() ?? '';
+  const state = parts.pop() ?? '';
   const city = parts.pop() ?? '';
-  const district = parts.pop() ?? '';
   const neighborhood = parts.pop() ?? '';
   const remaining = parts.join(', ');
 
   return {
+    country,
+    state,
     city,
-    district,
     neighborhood,
     street: remaining,
     buildingNo: '',
@@ -48,18 +52,20 @@ export const formatAddress = (value: AddressFieldsValue): string => {
   }
   const buildingSegment = [value.buildingNo.trim(), value.doorNo.trim()]
     .filter(Boolean)
-    .join(' ');
+    .join('/');
   if (buildingSegment) {
     segments.push(buildingSegment);
   }
   if (value.neighborhood.trim()) {
     segments.push(value.neighborhood.trim());
   }
-  if (value.district.trim()) {
-    segments.push(value.district.trim());
-  }
   if (value.city.trim()) {
     segments.push(value.city.trim());
+  }
+  if (value.state.trim()) {
+    segments.push(value.state.trim());
+  } if (value.country.trim()) {
+    segments.push(value.country.trim());
   }
   return segments.join(', ');
 };


### PR DESCRIPTION
### Changes

- Address entry now uses country-state-city for provinces/districts (global support) and treats neighborhood as free text. 

- In request creation added validation of the selected deadline: invalid timestamps or past times trigger an alert before hitting the API and therefore avoiding API call error.

### How to test


- In Create Request - Address selection step; verify city/district lists populate globally and Neighborhood input accepts text.

- Again in Create Request, try submitting with a past deadline  and confirm you get the new alert and no API call. Then submit with a valid future deadline to ensure the flow still works
