### PR TITLE
fix: location search and filter logic

### DIFF
--- a/app/mobile/app/requests.tsx
+++ b/app/mobile/app/requests.tsx
@@ -18,6 +18,7 @@ import { useRouter, useLocalSearchParams } from 'expo-router';
 import { getTasks, type Task } from '../lib/api';
 import { useAuth } from '../lib/auth';
 import { useAppTheme } from '../theme/ThemeProvider';
+import { locationMatches, normalizedLocationLabel } from '../utils/address';
 
 export default function Requests() {
   const { colors } = useTheme();
@@ -29,7 +30,7 @@ export default function Requests() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   
-  const locationFilter = params.location as string | undefined;
+  const locationLabel = (Array.isArray(params.location) ? params.location[0]?.trim() : params.location)?.trim() || undefined;
 
   // Filter out completed and cancelled tasks
   const filterActiveTasks = (tasksList: Task[]): Task[] => {
@@ -47,8 +48,8 @@ export default function Requests() {
       
       // Filter by location if location parameter is provided
       let filteredTasks = activeTasks;
-      if (locationFilter) {
-        filteredTasks = activeTasks.filter(task => task.location === locationFilter);
+      if (locationLabel) {
+        filteredTasks = activeTasks.filter(task => normalizedLocationLabel(task.location) === locationLabel);
       }
       
       setTasks(filteredTasks);
@@ -63,7 +64,7 @@ export default function Requests() {
 
   useEffect(() => {
     fetchTasks();
-  }, [locationFilter]);
+  }, [locationLabel]);
 
   const onRefresh = () => {
     setRefreshing(true);
@@ -157,9 +158,9 @@ export default function Requests() {
       <View style={styles.titleRow}>
         <View style={{ flex: 1, flexDirection: 'row', alignItems: 'center' }}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>
-            {locationFilter ? `Requests in ${locationFilter}` : 'All Requests'}
+            {locationLabel ? `Requests in ${locationLabel}` : 'All Requests'}
           </Text>
-          {locationFilter && (
+          {locationLabel && (
             <TouchableOpacity
               onPress={() => router.replace('/requests')}
               style={{ marginLeft: 8, padding: 4 }}
@@ -201,7 +202,7 @@ export default function Requests() {
 
               <View style={styles.cardContent}>
                 <Text style={[styles.cardTitle, { color: colors.text }]}>{task.title}</Text>
-                <Text style={[styles.cardMeta, { color: colors.text }]}>{`${task.location} • ${formatTimeAgo(task.created_at)}`}</Text>
+                <Text style={[styles.cardMeta, { color: colors.text }]}>{`${normalizedLocationLabel(task.location)} • ${formatTimeAgo(task.created_at)}`}</Text>
 
                 <View style={styles.pillRow}>
                   <View

--- a/app/mobile/app/search.tsx
+++ b/app/mobile/app/search.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 import { SafeAreaView, ActivityIndicator, Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import SearchBarWithResults, { Category, Request, Profile, Location } from '../components/ui/SearchBarWithResults';
-import { getTasks, searchUsers, type Task, type Category as ApiCategory, type UserProfile } from '../lib/api';
+import { getTasks, searchUsers, type Task, type UserProfile } from '../lib/api';
 import { useAuth } from '../lib/auth';
+import { normalizedLocationLabel, locationMatches } from '../utils/address';
 
 export default function SearchPage() {
   const router = useRouter();
@@ -32,14 +33,17 @@ export default function SearchPage() {
         const activeTasks = filterActiveTasks(fetchedTasks);
         setAllTasks(activeTasks);
         setRequests(
-          activeTasks.map((task) => ({
-            id: String(task.id),
-            title: task.title,
-            urgency: task.urgency_level === 3 ? 'High' : task.urgency_level === 2 ? 'Medium' : 'Low',
-            meta: `${task.location} • ${task.deadline ? new Date(task.deadline).toLocaleDateString() : 'N/A'}`,
-            category: task.category_display || task.category,
-            image: require('../assets/images/help.png'),
-          }))
+          activeTasks.map((task) => {
+            const locationLabel = normalizedLocationLabel(task.location);
+            return {
+              id: String(task.id),
+              title: task.title,
+              urgency: task.urgency_level === 3 ? 'High' : task.urgency_level === 2 ? 'Medium' : 'Low',
+              meta: `${locationLabel} • ${task.deadline ? new Date(task.deadline).toLocaleDateString() : 'N/A'}`,
+              category: task.category_display || task.category,
+              image: require('../assets/images/help.png'),
+            };
+          })
         );
 
         if (activeTasks.length > 0) {
@@ -58,20 +62,36 @@ export default function SearchPage() {
           });
           setCategories(Array.from(uniqueCategoriesMap.values()));
 
-          const uniqueLocationsMap = new Map<string, Location>();
+          const locationCount = new Map<string, number>();
+
+          const addLabel = (label: string) => {
+            const trimmed = label.trim();
+            if (!trimmed) return;
+
+            // Merge labels that match on parsed parts (e.g., city vs full label)
+            const existingKey = Array.from(locationCount.keys()).find(
+              (existing) =>
+                locationMatches(existing, trimmed) && locationMatches(trimmed, existing)
+            );
+            const key = existingKey ?? trimmed;
+            locationCount.set(key, (locationCount.get(key) ?? 0) + 1);
+          };
+
           activeTasks.forEach((task) => {
-            if (task.location) {
-              if (!uniqueLocationsMap.has(task.location)) {
-                uniqueLocationsMap.set(task.location, {
-                  id: task.location,
-                  title: task.location,
-                  image: require('../assets/images/help.png'),
-                  count: activeTasks.filter((t) => t.location === task.location).length,
-                });
-              }
-            }
+            if (!task.location) return;
+
+            const normalized = normalizedLocationLabel(task.location);
+            addLabel(normalized || task.location);
           });
-          setLocations(Array.from(uniqueLocationsMap.values()));
+
+          const locationList: Location[] = Array.from(locationCount.entries()).map(([label, count]) => ({
+            id: label,
+            title: label,
+            image: require('../assets/images/help.png'),
+            count,
+          }));
+
+          setLocations(locationList);
         } else {
           setCategories([]);
           setLocations([]);

--- a/app/mobile/components/ui/SearchBarWithResults.tsx
+++ b/app/mobile/components/ui/SearchBarWithResults.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, TextInput, Text, TouchableOpacity, ScrollView, StyleSheet, Image, ImageSourcePropType } from 'react-native';
 import { useTheme } from '@react-navigation/native';
+import { locationMatches } from '../../utils/address';
 
 export type Category = { id: string; title: string; count: number; image: ImageSourcePropType };
 export type Request = { id: string; title: string; urgency: string; meta?: string; category?: string; color?: string; image?: ImageSourcePropType };
@@ -62,7 +63,7 @@ export default function SearchBarWithResults({
     );
   } else if (tab === 'Locations') {
     filtered = sortByName(
-      locations.filter((loc) => loc.title.toLowerCase().includes(lowerSearch))
+      locations.filter((loc) => locationMatches(loc.title, lowerSearch))
     );
   }
 


### PR DESCRIPTION
Location is stored as a comma-separated string and previously filtering checked if the raw filter text was contained in that string; selecting a location compared that raw string exactly to a task’s location string.

### What Changed

- Searching now operates on city/state/country triplets extracted from the stored string.
- The search input is tokenized by commas or spaces, and a match requires every token to appear within the city/state/country parts.
- When a location is selected, tasks are included only if their city/state/country triplet matches the selected location label.