### PR TITLE
feat: Implement handling for banned users across various components

### DIFF
--- a/app/frontend/src/components/CommentSection.jsx
+++ b/app/frontend/src/components/CommentSection.jsx
@@ -228,6 +228,8 @@ const CommentSection = ({ taskId, currentUser, isAuthenticated }) => {
                   comment.user?.profilePhoto ||
                   comment.user?.avatar
               );
+              // Check if commenter is banned (name shows as *deleted)
+              const isCommenterBanned = comment.user?.name === "*deleted";
 
               return (
                 <div
@@ -260,7 +262,8 @@ const CommentSection = ({ taskId, currentUser, isAuthenticated }) => {
                         }
                       }}
                     >
-                      {userPhoto ? (
+                      {/* Don't show profile photo for banned users */}
+                      {userPhoto && !isCommenterBanned ? (
                         <img
                           src={userPhoto}
                           alt={`${comment.user?.name} ${comment.user?.surname}`}
@@ -270,7 +273,11 @@ const CommentSection = ({ taskId, currentUser, isAuthenticated }) => {
                       ) : (
                         <div
                           className="w-8 h-8 rounded-full flex items-center justify-center text-white font-semibold text-sm"
-                          style={{ backgroundColor: colors.brand.primary }}
+                          style={{
+                            backgroundColor: isCommenterBanned
+                              ? colors.text.tertiary
+                              : colors.brand.primary,
+                          }}
                         >
                           {comment.user?.name?.charAt(0) || "U"}
                         </div>
@@ -278,7 +285,11 @@ const CommentSection = ({ taskId, currentUser, isAuthenticated }) => {
                       <div>
                         <p
                           className="font-semibold text-sm"
-                          style={{ color: colors.text.primary }}
+                          style={{
+                            color: isCommenterBanned
+                              ? colors.text.tertiary
+                              : colors.text.primary,
+                          }}
                         >
                           {comment.user?.name} {comment.user?.surname}
                         </p>

--- a/app/frontend/src/components/ReviewCard.jsx
+++ b/app/frontend/src/components/ReviewCard.jsx
@@ -17,6 +17,9 @@ const ReviewCard = ({ review }) => {
       review.reviewer?.avatar
   );
 
+  // Check if reviewer is banned (name shows as *deleted)
+  const isReviewerBanned = review.reviewer?.name === "*deleted";
+
   // Get initials for fallback avatar
   const getInitials = () => {
     const name = review.reviewer?.name || "";
@@ -103,26 +106,34 @@ const ReviewCard = ({ review }) => {
           onClick={handleProfileClick}
         >
           <Avatar
-            src={reviewerPhoto || undefined}
+            src={!isReviewerBanned ? reviewerPhoto || undefined : undefined}
             alt={review.reviewer?.name || "User"}
             sx={{
               border: `2px solid ${colors.border.primary}`,
               width: 40,
               height: 40,
-              backgroundColor: !reviewerPhoto
-                ? colors.brand.primary
-                : undefined,
-              color: !reviewerPhoto ? colors.text.inverse : undefined,
+              backgroundColor:
+                !reviewerPhoto || isReviewerBanned
+                  ? isReviewerBanned
+                    ? colors.text.tertiary
+                    : colors.brand.primary
+                  : undefined,
+              color:
+                !reviewerPhoto || isReviewerBanned
+                  ? colors.text.inverse
+                  : undefined,
             }}
           >
-            {!reviewerPhoto && getInitials()}
+            {(!reviewerPhoto || isReviewerBanned) && getInitials()}
           </Avatar>
           <Box>
             <Typography
               variant="subtitle2"
               fontWeight="bold"
               sx={{
-                color: colors.text.primary,
+                color: isReviewerBanned
+                  ? colors.text.tertiary
+                  : colors.text.primary,
                 "&:hover": review.reviewer?.id
                   ? {
                       textDecoration: "underline",

--- a/app/frontend/src/pages/ProfilePage.jsx
+++ b/app/frontend/src/pages/ProfilePage.jsx
@@ -419,6 +419,9 @@ const ProfilePage = () => {
   const earnedBadges = badgesToUse.filter((badge) => badge.earned);
   const inProgressBadges = badgesToUse.filter((badge) => !badge.earned);
 
+  // Check if the profile being viewed belongs to a banned user
+  const isUserBanned = user?.name === "*deleted";
+
   // Get initials from name and surname for fallback avatar
   const getInitials = () => {
     const name = user?.name || "";
@@ -559,7 +562,9 @@ const ProfilePage = () => {
                     sx={{
                       width: 80,
                       height: 80,
-                      backgroundColor: colors.brand.primary,
+                      backgroundColor: isUserBanned
+                        ? colors.text.tertiary
+                        : colors.brand.primary,
                       fontSize: "2rem",
                       fontWeight: "semibold",
                     }}
@@ -619,7 +624,12 @@ const ProfilePage = () => {
                 <Typography
                   variant="h5"
                   component="h1"
-                  sx={{ textAlign: "left", color: colors.text.primary }}
+                  sx={{
+                    textAlign: "left",
+                    color: isUserBanned
+                      ? colors.text.tertiary
+                      : colors.text.primary,
+                  }}
                   id="profile-page-title"
                 >
                   {user.name} {user.surname}
@@ -656,8 +666,8 @@ const ProfilePage = () => {
                     }}
                   />
                 </Box>
-                {/* Report button - only show for other users, not own profile */}
-                {!canEdit && (
+                {/* Report button - only show for other users, not own profile, and not for banned users */}
+                {!canEdit && !isUserBanned && (
                   <Button
                     onClick={handleUserReport}
                     startIcon={<FlagIcon />}

--- a/app/frontend/src/pages/SelectVolunteer.jsx
+++ b/app/frontend/src/pages/SelectVolunteer.jsx
@@ -386,8 +386,11 @@ const SelectVolunteer = () => {
           <Grid container spacing={2} sx={{ mb: 3 }}>
             {volunteers.map((volunteer) => {
               const isSelected = selectedVolunteers.includes(volunteer.id);
+              // Check if volunteer is banned (name shows as *deleted)
+              const isVolunteerBanned = volunteer.name === "*deleted";
               const canSelect =
-                selectedVolunteers.length < maxVolunteers || isSelected;
+                (selectedVolunteers.length < maxVolunteers || isSelected) &&
+                !isVolunteerBanned; // Banned volunteers cannot be selected
               const isCurrentlyAccepted =
                 volunteer.volunteerRecord?.status === "ACCEPTED";
               const isCurrentlyRejected =
@@ -462,7 +465,7 @@ const SelectVolunteer = () => {
                       {/* Avatar and Selection Indicator */}
                       <Box sx={{ position: "relative", mb: 2 }}>
                         <Avatar
-                          src={volunteer.avatar}
+                          src={!isVolunteerBanned ? volunteer.avatar : undefined}
                           sx={{
                             width: 80,
                             height: 80,
@@ -470,8 +473,11 @@ const SelectVolunteer = () => {
                             border: isSelected
                               ? "3px solid #7c4dff"
                               : "3px solid transparent",
+                            bgcolor: isVolunteerBanned ? "#9e9e9e" : undefined,
                           }}
-                        />
+                        >
+                          {isVolunteerBanned && "*"}
+                        </Avatar>
                         {/* Selection Circle */}
                         <Box
                           sx={{
@@ -497,7 +503,16 @@ const SelectVolunteer = () => {
                       </Box>
 
                       {/* Name */}
-                      <Typography variant="h6" fontWeight="medium" gutterBottom>
+                      <Typography
+                        variant="h6"
+                        fontWeight="medium"
+                        gutterBottom
+                        sx={{
+                          color: isVolunteerBanned
+                            ? "text.disabled"
+                            : "text.primary",
+                        }}
+                      >
                         {volunteer.name} {volunteer.surname}
                       </Typography>
 


### PR DESCRIPTION
I have made use of the latest changes in the backend to implement the necessary visual improvements when a user is deleted. 

**Summary of Changes**

1. RequestDetail.jsx (app/frontend/src/pages/RequestDetail.jsx)

   - Added isCreatorBanned check to detect banned users (name === "*deleted")
   - Disabled volunteering for banned user's requests by adding !isCreatorBanned to canVolunteer logic
   - Added a disabled "Volunteering Unavailable" button when the creator is banned
   - Updated requester info section to show gray placeholder instead of profile photo for banned users
   - Grayed out the name display for banned users

2. ProfilePage.jsx (app/frontend/src/pages/ProfilePage.jsx)

   - Added isUserBanned check
   - Grayed out the name for banned user profiles
   - Gray avatar background for banned users
   - Hidden the Report button for banned users (can't report a deleted user)

3. CommentSection.jsx (app/frontend/src/components/CommentSection.jsx)

   - Added isCommenterBanned check for each comment
   - Gray avatar background and grayed out name for banned commenters
   - Profile photo is hidden for banned commenters

4. ReviewCard.jsx (app/frontend/src/components/ReviewCard.jsx)

   - Added isReviewerBanned check
   - Gray avatar background and grayed out name for banned reviewers
   - Profile photo is hidden for banned reviewers

5. SelectVolunteer.jsx (app/frontend/src/pages/SelectVolunteer.jsx)

   - Added isVolunteerBanned check
   - Banned volunteers cannot be selected for tasks
   - Gray avatar with "*" initial for banned volunteers
   - Grayed out name for banned volunteers