### PR TITLE
Fix: Search results not clickable

### DIFF
--- a/app/mobile/app/search.tsx
+++ b/app/mobile/app/search.tsx
@@ -102,10 +102,10 @@ export default function SearchPage() {
           setProfiles(
             usersResponse.results.map((prof: UserProfile) => {
               const photoUrl = prof.profile_photo || prof.photo;
-              const absolutePhotoUrl = photoUrl 
+              const absolutePhotoUrl = photoUrl
                 ? (photoUrl.startsWith('http') ? photoUrl : `${BACKEND_BASE_URL}${photoUrl}`)
                 : null;
-              
+
               return {
                 id: String(prof.id),
                 name: `${prof.name} ${prof.surname}`,
@@ -147,10 +147,10 @@ export default function SearchPage() {
         locations={locations}
         onSelect={(item, type: string) => {
           let mappedType: 'category' | 'request' | 'profile' | 'location' = type as any;
-          if (type === 'Categories') mappedType = 'category';
-          else if (type === 'Requests') mappedType = 'request';
-          else if (type === 'Profiles') mappedType = 'profile';
-          else if (type === 'Locations') mappedType = 'location';
+          if (type === 'Category') mappedType = 'category';
+          else if (type === 'Request') mappedType = 'request';
+          else if (type === 'Profile') mappedType = 'profile';
+          else if (type === 'Location') mappedType = 'location';
           if (mappedType === 'category') router.push(('/category/' + item.id) as any);
           else if (mappedType === 'request') {
             // Find the full task object to check if user is creator


### PR DESCRIPTION
This PR fixes issue in the search functionality where search results was not clickable. The issue was a name mismatch caused by changes in the search bar made earlier.