### PR TITLE
feat: activate notifications for comments

### DIFF
--- a/app/backend/core/signals.py
+++ b/app/backend/core/signals.py
@@ -70,4 +70,9 @@ def check_comment_badges(sender, instance, created, **kwargs):
     """Check and award badges when a comment is created"""
     if created:
         user = instance.user
+        # Award badges
         BadgeService.check_icebreaker(user)
+        
+        # Send notifications
+        from core.models import Notification
+        Notification.send_comment_added_notification(instance)

--- a/app/backend/core/tests/test_notification_models.py
+++ b/app/backend/core/tests/test_notification_models.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.utils import timezone
 import datetime
-from core.models import RegisteredUser, Task, Volunteer, Notification, NotificationType
+from core.models import RegisteredUser, Task, Volunteer, Notification, NotificationType, Comment
 
 
 class NotificationModelTests(TestCase):
@@ -227,6 +227,120 @@ class NotificationModelTests(TestCase):
         self.assertIn(badge.name, notification.content)
         self.assertIn(badge.description, notification.content)
         self.assertIn('Congratulations', notification.content)
+    
+    def test_comment_added_notification_to_creator(self):
+        """Test comment notification sent to task creator"""
+        # user2 comments on user1's task
+        comment = Comment.objects.create(
+            user=self.user2,
+            task=self.task,
+            content='This is a test comment on your task!'
+        )
+        
+        # Send notification
+        Notification.send_comment_added_notification(comment)
+        
+        # Verify creator received notification
+        creator_notification = Notification.objects.filter(
+            user=self.user1,
+            type=NotificationType.COMMENT_ADDED,
+            related_task=self.task
+        ).first()
+        
+        self.assertIsNotNone(creator_notification)
+        self.assertIn(self.user2.username, creator_notification.content)
+        self.assertIn(self.task.title, creator_notification.content)
+        self.assertIn('commented', creator_notification.content.lower())
+    
+    def test_comment_added_notification_to_assignee(self):
+        """Test comment notification sent to task assignee"""
+        # Create a third user as assignee
+        user3 = RegisteredUser.objects.create_user(
+            email='user3@example.com',
+            name='User',
+            surname='Three',
+            username='userthree',
+            phone_number='1111111111',
+            password='password789'
+        )
+        
+        # Assign task to user3
+        self.task.assignee = user3
+        self.task.save()
+        
+        # user2 comments on the task
+        comment = Comment.objects.create(
+            user=self.user2,
+            task=self.task,
+            content='Comment for both creator and assignee'
+        )
+        
+        # Send notification
+        Notification.send_comment_added_notification(comment)
+        
+        # Verify both creator and assignee received notifications
+        creator_notification = Notification.objects.filter(
+            user=self.user1,  # creator
+            type=NotificationType.COMMENT_ADDED,
+            related_task=self.task
+        ).first()
+        
+        assignee_notification = Notification.objects.filter(
+            user=user3,  # assignee
+            type=NotificationType.COMMENT_ADDED,
+            related_task=self.task
+        ).first()
+        
+        self.assertIsNotNone(creator_notification)
+        self.assertIsNotNone(assignee_notification)
+        self.assertIn(self.user2.username, creator_notification.content)
+        self.assertIn(self.user2.username, assignee_notification.content)
+    
+    def test_comment_added_no_self_notification(self):
+        """Test that user doesn't receive notification for their own comment"""
+        # user1 (creator) comments on their own task
+        comment = Comment.objects.create(
+            user=self.user1,
+            task=self.task,
+            content='I am commenting on my own task'
+        )
+        
+        # Send notification
+        Notification.send_comment_added_notification(comment)
+        
+        # Verify no notification was sent to user1
+        notifications = Notification.objects.filter(
+            user=self.user1,
+            type=NotificationType.COMMENT_ADDED,
+            related_task=self.task
+        )
+        
+        self.assertEqual(notifications.count(), 0)
+    
+    def test_comment_added_notification_truncates_long_content(self):
+        """Test that long comment content is truncated in notification"""
+        # Create a long comment
+        long_content = 'A' * 100  # 100 characters
+        comment = Comment.objects.create(
+            user=self.user2,
+            task=self.task,
+            content=long_content
+        )
+        
+        # Send notification
+        Notification.send_comment_added_notification(comment)
+        
+        # Verify notification content is truncated
+        creator_notification = Notification.objects.filter(
+            user=self.user1,
+            type=NotificationType.COMMENT_ADDED,
+            related_task=self.task
+        ).first()
+        
+        self.assertIsNotNone(creator_notification)
+        self.assertIn('...', creator_notification.content)
+        # The actual comment preview should be 50 characters
+        self.assertTrue(long_content[:50] in creator_notification.content)
 
 
 class NotificationTypeEnumTests(TestCase):
@@ -241,6 +355,7 @@ class NotificationTypeEnumTests(TestCase):
         self.assertEqual(NotificationType.TASK_CANCELLED, 'TASK_CANCELLED')
         self.assertEqual(NotificationType.NEW_REVIEW, 'NEW_REVIEW')
         self.assertEqual(NotificationType.BADGE_EARNED, 'BADGE_EARNED')
+        self.assertEqual(NotificationType.COMMENT_ADDED, 'COMMENT_ADDED')
         self.assertEqual(NotificationType.SYSTEM_NOTIFICATION, 'SYSTEM_NOTIFICATION')
         
         # Test choices format
@@ -248,3 +363,4 @@ class NotificationTypeEnumTests(TestCase):
         self.assertTrue(('TASK_CREATED', 'Task Created') in choices)
         self.assertTrue(('NEW_REVIEW', 'New Review') in choices)
         self.assertTrue(('BADGE_EARNED', 'Badge Earned') in choices)
+        self.assertTrue(('COMMENT_ADDED', 'Comment Added') in choices)


### PR DESCRIPTION
## Feature: Comment Notifications

### Summary
Implements notification system for the comment feature. Users now receive real-time notifications when someone comments on their tasks.

### Changes Made

#### 1. **Notification Model** ([notification.py](app/backend/core/models/notification.py))
- Added `COMMENT_ADDED` to `NotificationType` enum
- Implemented `send_comment_added_notification()` method with smart logic:
  - Notifies task creator (unless they wrote the comment)
  - Notifies task assignee (if exists and different from creator/commenter)
  - Truncates long comments to 50 characters in notification preview

#### 2. **Signals** ([signals.py](app/backend/core/signals.py))
- Enhanced `check_comment_badges()` signal to automatically trigger notifications
- Notifications sent automatically when `Comment` model is created

#### 3. **Tests** ([test_notification_models.py](app/backend/core/tests/test_notification_models.py))
- `test_comment_added_notification_to_creator` - Verifies creator receives notification
- `test_comment_added_notification_to_assignee` - Verifies assignee receives notification
- `test_comment_added_no_self_notification` - Ensures no self-notifications
- `test_comment_added_notification_truncates_long_content` - Tests content truncation
- Updated `test_notification_type_enum` to include `COMMENT_ADDED`

### Testing
✅ All 16 notification tests pass  
✅ Integration test confirms signals work correctly  
✅ No regression in existing functionality

### Usage
Notifications are automatically created when comments are added via:
- `Comment.add_comment(user, task, content)` 
- `Comment.objects.create(...)` 
- API endpoints using `CommentCreateSerializer`

Closes #817
