### PR TITLE
feat:admin can send users warnings

### DIFF
--- a/app/backend/core/api/serializers/notification_serializers.py
+++ b/app/backend/core/api/serializers/notification_serializers.py
@@ -89,3 +89,28 @@ class NotificationUpdateSerializer(serializers.ModelSerializer):
             instance.save()
         
         return instance
+
+
+class AdminWarningSerializer(serializers.Serializer):
+    """Serializer for admin sending warnings to users"""
+    user_id = serializers.IntegerField(required=True, help_text="ID of the user to warn")
+    message = serializers.CharField(
+        required=True, 
+        max_length=500,
+        help_text="Warning message to send to the user"
+    )
+    
+    def validate_user_id(self, value):
+        """Validate that the user exists"""
+        from core.models import RegisteredUser
+        try:
+            RegisteredUser.objects.get(id=value)
+            return value
+        except RegisteredUser.DoesNotExist:
+            raise serializers.ValidationError("User not found.")
+    
+    def validate_message(self, value):
+        """Validate the warning message"""
+        if not value.strip():
+            raise serializers.ValidationError("Warning message cannot be empty.")
+        return value.strip()

--- a/app/backend/core/models/notification.py
+++ b/app/backend/core/models/notification.py
@@ -11,6 +11,7 @@ class NotificationType(models.TextChoices):
     NEW_REVIEW = 'NEW_REVIEW', 'New Review'
     BADGE_EARNED = 'BADGE_EARNED', 'Badge Earned'
     COMMENT_ADDED = 'COMMENT_ADDED', 'Comment Added'
+    ADMIN_WARNING = 'ADMIN_WARNING', 'Admin Warning'
     SYSTEM_NOTIFICATION = 'SYSTEM_NOTIFICATION', 'System Notification'
 
 
@@ -194,3 +195,16 @@ class Notification(models.Model):
                 notification_type=NotificationType.COMMENT_ADDED,
                 related_task=task
             )
+    
+    @classmethod
+    def send_admin_warning(cls, user, message, admin_user=None):
+        """Send an administrative warning to a user"""
+        admin_name = admin_user.username if admin_user else "Administrator"
+        content = f"⚠️ Warning from {admin_name}: {message}"
+        
+        return cls.send_notification(
+            user=user,
+            content=content,
+            notification_type=NotificationType.ADMIN_WARNING,
+            related_task=None
+        )

--- a/app/backend/core/tests/test_admin_warning_api.py
+++ b/app/backend/core/tests/test_admin_warning_api.py
@@ -1,0 +1,230 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework import status
+import datetime
+
+from core.models import RegisteredUser, Notification, NotificationType
+
+
+class AdminWarningAPITests(TestCase):
+    """Test cases for admin warning API endpoint"""
+
+    def setUp(self):
+        """Set up test data"""
+        self.client = APIClient()
+        
+        # Create regular user
+        self.regular_user = RegisteredUser.objects.create_user(
+            email='regular@example.com',
+            name='Regular',
+            surname='User',
+            username='regularuser',
+            phone_number='1234567890',
+            password='password123'
+        )
+        
+        # Create admin user
+        self.admin_user = RegisteredUser.objects.create_user(
+            email='admin@example.com',
+            name='Admin',
+            surname='User',
+            username='adminuser',
+            phone_number='0987654321',
+            password='admin123',
+            is_staff=True
+        )
+        
+        # Create another regular user to receive warnings
+        self.target_user = RegisteredUser.objects.create_user(
+            email='target@example.com',
+            name='Target',
+            surname='User',
+            username='targetuser',
+            phone_number='1111111111',
+            password='target123'
+        )
+    
+    def test_admin_can_send_warning(self):
+        """Test that admin can send warning to user"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        url = '/api/notifications/send-warning/'
+        data = {
+            'user_id': self.target_user.id,
+            'message': 'Please follow community guidelines.'
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['status'], 'success')
+        self.assertIn('Warning sent', response.data['message'])
+        
+        # Verify notification was created
+        notification = Notification.objects.filter(
+            user=self.target_user,
+            type=NotificationType.ADMIN_WARNING
+        ).first()
+        
+        self.assertIsNotNone(notification)
+        self.assertIn(self.admin_user.username, notification.content)
+        self.assertIn('Please follow community guidelines', notification.content)
+    
+    def test_regular_user_cannot_send_warning(self):
+        """Test that regular user cannot send warnings"""
+        self.client.force_authenticate(user=self.regular_user)
+        
+        url = '/api/notifications/send-warning/'
+        data = {
+            'user_id': self.target_user.id,
+            'message': 'This should not work.'
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data['status'], 'error')
+        self.assertIn('Only administrators', response.data['message'])
+        
+        # Verify no notification was created
+        notification_count = Notification.objects.filter(
+            user=self.target_user,
+            type=NotificationType.ADMIN_WARNING
+        ).count()
+        
+        self.assertEqual(notification_count, 0)
+    
+    def test_unauthenticated_user_cannot_send_warning(self):
+        """Test that unauthenticated user cannot send warnings"""
+        url = '/api/notifications/send-warning/'
+        data = {
+            'user_id': self.target_user.id,
+            'message': 'This should not work.'
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+    
+    def test_send_warning_invalid_user_id(self):
+        """Test sending warning to non-existent user"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        url = '/api/notifications/send-warning/'
+        data = {
+            'user_id': 99999,
+            'message': 'This should fail.'
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_send_warning_empty_message(self):
+        """Test sending warning with empty message"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        url = '/api/notifications/send-warning/'
+        data = {
+            'user_id': self.target_user.id,
+            'message': '   '
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_send_warning_missing_fields(self):
+        """Test sending warning with missing required fields"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        url = '/api/notifications/send-warning/'
+        
+        # Missing message
+        data = {'user_id': self.target_user.id}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        
+        # Missing user_id
+        data = {'message': 'Some message'}
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_send_warning_long_message(self):
+        """Test sending warning with valid long message"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        url = '/api/notifications/send-warning/'
+        long_message = 'A' * 400  # 400 characters, within 500 limit
+        data = {
+            'user_id': self.target_user.id,
+            'message': long_message
+        }
+        
+        response = self.client.post(url, data, format='json')
+        
+        # Verify response
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        
+        # Verify notification contains the message
+        notification = Notification.objects.filter(
+            user=self.target_user,
+            type=NotificationType.ADMIN_WARNING
+        ).first()
+        
+        self.assertIsNotNone(notification)
+        self.assertIn(long_message, notification.content)
+    
+    def test_admin_can_send_multiple_warnings(self):
+        """Test that admin can send multiple warnings to different users"""
+        self.client.force_authenticate(user=self.admin_user)
+        
+        # Create another target user
+        target_user2 = RegisteredUser.objects.create_user(
+            email='target2@example.com',
+            name='Target2',
+            surname='User',
+            username='targetuser2',
+            phone_number='2222222222',
+            password='target456'
+        )
+        
+        url = '/api/notifications/send-warning/'
+        
+        # Send first warning
+        data1 = {
+            'user_id': self.target_user.id,
+            'message': 'First warning message'
+        }
+        response1 = self.client.post(url, data1, format='json')
+        self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
+        
+        # Send second warning to different user
+        data2 = {
+            'user_id': target_user2.id,
+            'message': 'Second warning message'
+        }
+        response2 = self.client.post(url, data2, format='json')
+        self.assertEqual(response2.status_code, status.HTTP_201_CREATED)
+        
+        # Verify both notifications were created
+        notification1 = Notification.objects.filter(
+            user=self.target_user,
+            type=NotificationType.ADMIN_WARNING
+        ).first()
+        
+        notification2 = Notification.objects.filter(
+            user=target_user2,
+            type=NotificationType.ADMIN_WARNING
+        ).first()
+        
+        self.assertIsNotNone(notification1)
+        self.assertIsNotNone(notification2)
+        self.assertIn('First warning message', notification1.content)
+        self.assertIn('Second warning message', notification2.content)

--- a/app/backend/core/tests/test_notification_models.py
+++ b/app/backend/core/tests/test_notification_models.py
@@ -341,6 +341,53 @@ class NotificationModelTests(TestCase):
         self.assertIn('...', creator_notification.content)
         # The actual comment preview should be 50 characters
         self.assertTrue(long_content[:50] in creator_notification.content)
+    
+    def test_admin_warning_notification(self):
+        """Test admin warning notification"""
+        # Create an admin user
+        admin = RegisteredUser.objects.create_user(
+            email='admin@example.com',
+            name='Admin',
+            surname='User',
+            username='adminuser',
+            phone_number='9999999999',
+            password='admin123',
+            is_staff=True
+        )
+        
+        # Send warning to user1
+        warning_message = "Please follow community guidelines."
+        notification = Notification.send_admin_warning(
+            user=self.user1,
+            message=warning_message,
+            admin_user=admin
+        )
+        
+        # Verify notification
+        self.assertIsNotNone(notification)
+        self.assertEqual(notification.user, self.user1)
+        self.assertEqual(notification.type, NotificationType.ADMIN_WARNING)
+        self.assertIsNone(notification.related_task)
+        self.assertIn(admin.username, notification.content)
+        self.assertIn(warning_message, notification.content)
+        self.assertIn('⚠️', notification.content)
+        self.assertIn('Warning', notification.content)
+    
+    def test_admin_warning_notification_without_admin_user(self):
+        """Test admin warning notification when admin user is not provided"""
+        warning_message = "This is a system warning."
+        notification = Notification.send_admin_warning(
+            user=self.user1,
+            message=warning_message,
+            admin_user=None
+        )
+        
+        # Verify notification
+        self.assertIsNotNone(notification)
+        self.assertEqual(notification.user, self.user1)
+        self.assertEqual(notification.type, NotificationType.ADMIN_WARNING)
+        self.assertIn('Administrator', notification.content)
+        self.assertIn(warning_message, notification.content)
 
 
 class NotificationTypeEnumTests(TestCase):
@@ -356,6 +403,7 @@ class NotificationTypeEnumTests(TestCase):
         self.assertEqual(NotificationType.NEW_REVIEW, 'NEW_REVIEW')
         self.assertEqual(NotificationType.BADGE_EARNED, 'BADGE_EARNED')
         self.assertEqual(NotificationType.COMMENT_ADDED, 'COMMENT_ADDED')
+        self.assertEqual(NotificationType.ADMIN_WARNING, 'ADMIN_WARNING')
         self.assertEqual(NotificationType.SYSTEM_NOTIFICATION, 'SYSTEM_NOTIFICATION')
         
         # Test choices format
@@ -364,3 +412,4 @@ class NotificationTypeEnumTests(TestCase):
         self.assertTrue(('NEW_REVIEW', 'New Review') in choices)
         self.assertTrue(('BADGE_EARNED', 'Badge Earned') in choices)
         self.assertTrue(('COMMENT_ADDED', 'Comment Added') in choices)
+        self.assertTrue(('ADMIN_WARNING', 'Admin Warning') in choices)


### PR DESCRIPTION
## Feature: Admin Warning System

### Summary
Administrators can now send warning notifications to users for policy violations.

### Changes
- **Model**: Added `ADMIN_WARNING` type and `send_admin_warning()` method
- **API**: `POST /api/notifications/send-warning/` (admin-only, requires `user_id` and `message`)
- **Serializer**: `AdminWarningSerializer` with validation (500 char limit, non-empty)
- **Tests**: 2 model + 8 API tests, all passing

### Usage
```bash
POST /api/notifications/send-warning/
{
  "user_id": 123,
  "message": "Please follow community guidelines."
}

Closes #819