### PR TITLE
feat(backend): add OpenAPI/Swagger API documentation

### DIFF
--- a/app/backend/neighborhood_assistance_board/settings.py
+++ b/app/backend/neighborhood_assistance_board/settings.py
@@ -17,6 +17,7 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'corsheaders',
     'core',
+    'drf_spectacular',
 ]
 
 REST_FRAMEWORK = {
@@ -28,6 +29,14 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 20,
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Neighborhood Assistance Board API',
+    'DESCRIPTION': 'API for neighborhood assistance and task management',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 MIDDLEWARE = [

--- a/app/backend/neighborhood_assistance_board/urls.py
+++ b/app/backend/neighborhood_assistance_board/urls.py
@@ -18,11 +18,16 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView, SpectacularRedocView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('core.urls')),  # Include core URLs for API endpoints
     path('api-auth/', include('rest_framework.urls')),
+    # OpenAPI/Swagger Documentation
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('api/redoc/', SpectacularRedocView.as_view(url_name='schema'), name='redoc'),
 ]
 
 # Add media URL configuration for both development and production

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework>=3.12.0,<4.0.0
 psycopg2-binary>=2.9.0,<3.0.0
 Pillow>=9.0.0
 django-cors-headers>=4.0.0
+drf-spectacular>=0.27.0


### PR DESCRIPTION
- Integrate drf-spectacular for automatic OpenAPI 3.0 schema generation
- Add Swagger UI endpoint at /api/docs/ for interactive API testing
- Add ReDoc endpoint at /api/redoc/ for readable documentation
- Add raw OpenAPI schema endpoint at /api/schema/